### PR TITLE
1.0.4

### DIFF
--- a/AutoRest/AutoRest.psd1
+++ b/AutoRest/AutoRest.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'AutoRest.psm1'
 
 	# Version number of this module.
-	ModuleVersion = '1.0.2'
+	ModuleVersion = '1.0.4'
 
 	# ID used to uniquely identify this module
 	GUID = '18c33632-995c-4b5e-82fb-c52c2f6a176f'

--- a/AutoRest/changelog.md
+++ b/AutoRest/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 1.0.4 (2024-03-18)
+
++ Upd: Export-ARCommand - Added `Start-` to the list of verbs that defaults to skip ShouldProcess requirements.
++ Fix: Export-ARCommand - ConvertToHashtableCommand is not respected for translating common parameters
+
 ## 1.0.2
 
 + Upd: Added support to pass through some common parameters via `PassThruActions` command setting

--- a/AutoRest/internal/classes/02-Command.ps1
+++ b/AutoRest/internal/classes/02-Command.ps1
@@ -91,7 +91,7 @@
     }
 
     [string]ToParam() {
-		if (-not $this.ShouldProcess -and $this.Name -match '^New-|^Remove-|^Set-') {
+		if (-not $this.ShouldProcess -and $this.Name -match '^New-|^Remove-|^Set-|^Start-') {
 			$this.PssaRulesIgnored = @($this.PssaRulesIgnored) + @('PSUseShouldProcessForStateChangingFunctions')
 		}
 		$pssaString = ''
@@ -126,7 +126,7 @@ $($this.Parameters.Values | Sort-Object Weight | ForEach-Object ToParam | Join-S
             $pathModifier = 'if (${0}) {{ $__param.Path += "/${0}" }}' -f $optionalParameter.Name
         }
 		$actionsString = ''
-		if ($this.PassThruActions) { $actionsString = "`$__param += `$PSBoundParameters | ConvertTo-Hashtable -Include 'ErrorAction', 'WarningAction', 'Verbose'" }
+		if ($this.PassThruActions) { $actionsString = "`$__param += `$PSBoundParameters | $($this.ConvertToHashtableCommand) -Include 'ErrorAction', 'WarningAction', 'Verbose'" }
         $scopesString = ''
         if ($this.Scopes) { $scopesString = 'RequiredScopes = {0}' -f ($this.Scopes | Add-String "'" "'" | Join-String ',') }
         $processorString = ''
@@ -160,7 +160,8 @@ $mappingString
 		$pathModifier
 		$actionsString
 $shouldProcessString
-		$($this.RestCommand) @__param$($miscParameterString)$($processorString)
+		try { $($this.RestCommand) @__param$($miscParameterString)$($processorString) }
+		catch { `$PSCmdlet.ThrowTerminatingError(`$_) }
 "@
     }
 


### PR DESCRIPTION
+ Upd: Export-ARCommand - Added `Start-` to the list of verbs that defaults to skip ShouldProcess requirements.
+ Fix: Export-ARCommand - ConvertToHashtableCommand is not respected for translating common parameters